### PR TITLE
[ADDED] JetStream API traffic counters exposed via Jsz

### DIFF
--- a/server/consumer.go
+++ b/server/consumer.go
@@ -2529,6 +2529,10 @@ func (am *jsAckMsg) returnToPool() {
 // Push the ack message to the consumer's ackMsgs queue
 func (o *consumer) pushAck(_ *subscription, c *client, _ *Account, subject, reply string, rmsg []byte) {
 	atomic.AddInt64(&o.awl, 1)
+	// Track the ACK for traffic stats.
+	if o.js != nil {
+		o.js.trackAPICall(JSAPIAck)
+	}
 	o.ackMsgs.push(newJSAckMsg(subject, reply, c.pa.hdr, copyBytes(rmsg)))
 }
 
@@ -5293,6 +5297,11 @@ func (o *consumer) needFlowControl(sz int) bool {
 }
 
 func (o *consumer) processFlowControl(_ *subscription, c *client, _ *Account, subj, _ string, _ []byte) {
+	// Track flow control for traffic stats.
+	if o.js != nil {
+		o.js.trackAPICall(JSAPIFlowControl)
+	}
+
 	o.mu.Lock()
 	defer o.mu.Unlock()
 

--- a/server/consumer.go
+++ b/server/consumer.go
@@ -2530,9 +2530,7 @@ func (am *jsAckMsg) returnToPool() {
 func (o *consumer) pushAck(_ *subscription, c *client, _ *Account, subject, reply string, rmsg []byte) {
 	atomic.AddInt64(&o.awl, 1)
 	// Track the ACK for traffic stats using dedicated counter.
-	if o.js != nil {
-		o.js.trackAck()
-	}
+	o.js.trackAck()
 	o.ackMsgs.push(newJSAckMsg(subject, reply, c.pa.hdr, copyBytes(rmsg)))
 }
 
@@ -5091,9 +5089,7 @@ func (o *consumer) loopAndGatherMsgs(qch chan struct{}) {
 // Lock should be held.
 func (o *consumer) sendIdleHeartbeat(subj string) {
 	// Track heartbeat for traffic stats using dedicated counter.
-	if o.js != nil {
-		o.js.trackHeartbeat()
-	}
+	o.js.trackHeartbeat()
 	const t = "NATS/1.0 100 Idle Heartbeat\r\n%s: %d\r\n%s: %d\r\n\r\n"
 	sseq, dseq := o.sseq-1, o.dseq-1
 	hdr := fmt.Appendf(nil, t, JSLastConsumerSeq, dseq, JSLastStreamSeq, sseq)

--- a/server/consumer.go
+++ b/server/consumer.go
@@ -4119,9 +4119,7 @@ func (o *consumer) processNextMsgReq(_ *subscription, c *client, _ *Account, _, 
 	}
 
 	// Track the API call for traffic stats.
-	if o.js != nil {
-		o.js.trackAPICall(JSAPIConsumerMsgNext)
-	}
+	o.js.trackAPICall(JSAPIConsumerMsgNext)
 
 	// Short circuit error here.
 	if o.nextMsgReqs == nil {

--- a/server/jetstream.go
+++ b/server/jetstream.go
@@ -187,8 +187,10 @@ type jetStream struct {
 	storeReserved int64
 	memUsed       int64
 	storeUsed     int64
-	queueLimit    int64
-	clustered     int32
+	queueLimit      int64
+	acksTotal       int64 // Dedicated counter for ACKs (highest traffic)
+	heartbeatsTotal int64 // Dedicated counter for outgoing idle heartbeats
+	clustered       int32
 
 	// Traffic counters for each JS API type (must be 64-bit aligned for atomics on 32-bit systems)
 	apiTraffic [JSAPITypeCount]int64
@@ -2630,8 +2632,27 @@ func (js *jetStream) trackAPICall(apiType JSAPIType) {
 	}
 }
 
-// apiTrafficStats returns the current traffic statistics for all JS API types.
-func (js *jetStream) apiTrafficStats() *JSAPITrafficStats {
+// trackAPICall increments the traffic counter for the given API type via the server's JetStream instance.
+func (s *Server) trackAPICall(apiType JSAPIType) {
+	if js := s.getJetStream(); js != nil {
+		js.trackAPICall(apiType)
+	}
+}
+
+// trackAck increments the dedicated ACK traffic counter.
+// This is separate from apiTraffic to avoid cache line contention since ACKs are the highest traffic.
+func (js *jetStream) trackAck() {
+	atomic.AddInt64(&js.acksTotal, 1)
+}
+
+// trackHeartbeat increments the dedicated heartbeat counter.
+// This is separate from apiTraffic to avoid cache line contention since heartbeats can be high traffic.
+func (js *jetStream) trackHeartbeat() {
+	atomic.AddInt64(&js.heartbeatsTotal, 1)
+}
+
+// apiStats returns the current traffic statistics for all JS API types.
+func (js *jetStream) apiStats() *JSAPITrafficStats {
 	return &JSAPITrafficStats{
 		Info:                     uint64(atomic.LoadInt64(&js.apiTraffic[JSAPIInfo])),
 		StreamCreate:             uint64(atomic.LoadInt64(&js.apiTraffic[JSAPIStreamCreate])),
@@ -2662,9 +2683,9 @@ func (js *jetStream) apiTrafficStats() *JSAPITrafficStats {
 		AccountPurge:             uint64(atomic.LoadInt64(&js.apiTraffic[JSAPIAccountPurge])),
 		AccountStreamMove:        uint64(atomic.LoadInt64(&js.apiTraffic[JSAPIAccountStreamMove])),
 		AccountStreamCancelMove:  uint64(atomic.LoadInt64(&js.apiTraffic[JSAPIAccountStreamCancelMove])),
-		Ack:                      uint64(atomic.LoadInt64(&js.apiTraffic[JSAPIAck])),
+		Ack:                      uint64(atomic.LoadInt64(&js.acksTotal)),
 		FlowControl:              uint64(atomic.LoadInt64(&js.apiTraffic[JSAPIFlowControl])),
-		Heartbeat:                uint64(atomic.LoadInt64(&js.apiTraffic[JSAPIHeartbeat])),
+		Heartbeat:                uint64(atomic.LoadInt64(&js.heartbeatsTotal)),
 		Unknown:                  uint64(atomic.LoadInt64(&js.apiTraffic[JSAPIUnknown])),
 	}
 }

--- a/server/jetstream.go
+++ b/server/jetstream.go
@@ -146,7 +146,6 @@ type JSAPILatencyStats struct {
 	P50 int64 `json:"p50"` // 50th percentile (median) in microseconds
 	P90 int64 `json:"p90"` // 90th percentile in microseconds
 	P99 int64 `json:"p99"` // 99th percentile in microseconds
-	Max int64 `json:"max"` // Maximum latency in microseconds
 }
 
 // JSAPITrafficStats holds per-subject traffic counters for JetStream API
@@ -2788,7 +2787,6 @@ func (t *jsAPILatencyTracker) stats() *JSAPILatencyStats {
 		P50: sorted[n*50/100],
 		P90: sorted[n*90/100],
 		P99: sorted[n*99/100],
-		Max: sorted[n-1],
 	}
 }
 

--- a/server/jetstream.go
+++ b/server/jetstream.go
@@ -2793,12 +2793,18 @@ func (t *jsAPILatencyTracker) stats() *JSAPILatencyStats {
 // trackAck increments the dedicated ACK traffic counter.
 // This is separate from apiTraffic to avoid cache line contention since ACKs are the highest traffic.
 func (js *jetStream) trackAck() {
+	if js == nil {
+		return
+	}
 	atomic.AddInt64(&js.acksTotal, 1)
 }
 
 // trackHeartbeat increments the dedicated heartbeat counter.
 // This is separate from apiTraffic to avoid cache line contention since heartbeats can be high traffic.
 func (js *jetStream) trackHeartbeat() {
+	if js == nil {
+		return
+	}
 	atomic.AddInt64(&js.heartbeatsTotal, 1)
 }
 

--- a/server/jetstream.go
+++ b/server/jetstream.go
@@ -2695,6 +2695,9 @@ func (js *jetStream) usageStats() *JetStreamStats {
 
 // trackAPICall increments the traffic counter for the given API type.
 func (js *jetStream) trackAPICall(apiType JSAPIType) {
+	if js == nil {
+		return
+	}
 	if apiType >= 0 && apiType < JSAPITypeCount {
 		atomic.AddInt64(&js.apiTraffic[apiType], 1)
 	}
@@ -2703,7 +2706,7 @@ func (js *jetStream) trackAPICall(apiType JSAPIType) {
 // trackAPIStart increments the traffic counter and returns the start time for latency tracking.
 // The returned time should be passed to trackAPIEnd when the request completes.
 func (js *jetStream) trackAPIStart(apiType JSAPIType) time.Time {
-	if apiType >= 0 && apiType < JSAPITypeCount {
+	if js != nil && apiType >= 0 && apiType < JSAPITypeCount {
 		atomic.AddInt64(&js.apiTraffic[apiType], 1)
 	}
 	return time.Now()
@@ -2712,7 +2715,7 @@ func (js *jetStream) trackAPIStart(apiType JSAPIType) time.Time {
 // trackAPIEnd records the latency for the given API type.
 // Should be called with the start time returned by trackAPIStart.
 func (js *jetStream) trackAPIEnd(apiType JSAPIType, start time.Time) {
-	if apiType < 0 || apiType >= JSAPITypeCount {
+	if js == nil || apiType < 0 || apiType >= JSAPITypeCount {
 		return
 	}
 	tracker := js.apiLatency[apiType]

--- a/server/jetstream.go
+++ b/server/jetstream.go
@@ -143,12 +143,10 @@ const (
 
 // JSAPILatencyStats holds latency percentile data for a single API type
 type JSAPILatencyStats struct {
-	Avg float64 `json:"avg"` // Average latency in microseconds
-	P50 int64   `json:"p50"` // 50th percentile (median) in microseconds
-	P90 int64   `json:"p90"` // 90th percentile in microseconds
-	P99 int64   `json:"p99"` // 99th percentile in microseconds
-	Min int64   `json:"min"` // Minimum latency in microseconds
-	Max int64   `json:"max"` // Maximum latency in microseconds
+	P50 int64 `json:"p50"` // 50th percentile (median) in microseconds
+	P90 int64 `json:"p90"` // 90th percentile in microseconds
+	P99 int64 `json:"p99"` // 99th percentile in microseconds
+	Max int64 `json:"max"` // Maximum latency in microseconds
 }
 
 // JSAPITrafficStats holds per-subject traffic counters for JetStream API
@@ -2786,18 +2784,10 @@ func (t *jsAPILatencyTracker) stats() *JSAPILatencyStats {
 	copy(sorted, t.samples)
 	slices.Sort(sorted)
 
-	// Calculate statistics
-	var sum int64
-	for _, v := range sorted {
-		sum += v
-	}
-
 	return &JSAPILatencyStats{
-		Avg: float64(sum) / float64(n),
 		P50: sorted[n*50/100],
 		P90: sorted[n*90/100],
 		P99: sorted[n*99/100],
-		Min: sorted[0],
 		Max: sorted[n-1],
 	}
 }

--- a/server/jetstream_api.go
+++ b/server/jetstream_api.go
@@ -1216,7 +1216,7 @@ func (s *Server) jsAccountInfoRequest(sub *subscription, c *client, _ *Account, 
 	if c == nil || !s.JetStreamEnabled() {
 		return
 	}
-	s.trackAPICall(JSAPIInfo)
+	defer s.trackAPI(JSAPIInfo)()
 
 	ci, acc, hdr, msg, err := s.getRequestInfo(c, rmsg)
 	if err != nil {
@@ -1313,7 +1313,7 @@ func (s *Server) jsStreamCreateRequest(sub *subscription, c *client, _ *Account,
 	if c == nil || !s.JetStreamEnabled() {
 		return
 	}
-	s.trackAPICall(JSAPIStreamCreate)
+	defer s.trackAPI(JSAPIStreamCreate)()
 	ci, acc, hdr, msg, err := s.getRequestInfo(c, rmsg)
 	if err != nil {
 		s.Warnf(badAPIRequestT, msg)
@@ -1430,7 +1430,7 @@ func (s *Server) jsStreamUpdateRequest(sub *subscription, c *client, _ *Account,
 	if c == nil || !s.JetStreamEnabled() {
 		return
 	}
-	s.trackAPICall(JSAPIStreamUpdate)
+	defer s.trackAPI(JSAPIStreamUpdate)()
 
 	ci, acc, hdr, msg, err := s.getRequestInfo(c, rmsg)
 	if err != nil {
@@ -1535,7 +1535,7 @@ func (s *Server) jsStreamNamesRequest(sub *subscription, c *client, _ *Account, 
 	if c == nil || !s.JetStreamEnabled() {
 		return
 	}
-	s.trackAPICall(JSAPIStreamNames)
+	defer s.trackAPI(JSAPIStreamNames)()
 	ci, acc, hdr, msg, err := s.getRequestInfo(c, rmsg)
 	if err != nil {
 		s.Warnf(badAPIRequestT, msg)
@@ -1668,7 +1668,7 @@ func (s *Server) jsStreamListRequest(sub *subscription, c *client, _ *Account, s
 	if c == nil || !s.JetStreamEnabled() {
 		return
 	}
-	s.trackAPICall(JSAPIStreamList)
+	defer s.trackAPI(JSAPIStreamList)()
 	ci, acc, hdr, msg, err := s.getRequestInfo(c, rmsg)
 	if err != nil {
 		s.Warnf(badAPIRequestT, msg)
@@ -1787,7 +1787,7 @@ func (s *Server) jsStreamInfoRequest(sub *subscription, c *client, a *Account, s
 	if c == nil || !s.JetStreamEnabled() {
 		return
 	}
-	s.trackAPICall(JSAPIStreamInfo)
+	defer s.trackAPI(JSAPIStreamInfo)()
 	ci, acc, hdr, msg, err := s.getRequestInfo(c, rmsg)
 	if err != nil {
 		s.Warnf(badAPIRequestT, msg)
@@ -2012,7 +2012,7 @@ func (s *Server) jsStreamLeaderStepDownRequest(sub *subscription, c *client, _ *
 	if c == nil || !s.JetStreamEnabled() {
 		return
 	}
-	s.trackAPICall(JSAPIStreamLeaderStepdown)
+	defer s.trackAPI(JSAPIStreamLeaderStepdown)()
 	ci, acc, hdr, msg, err := s.getRequestInfo(c, rmsg)
 	if err != nil {
 		s.Warnf(badAPIRequestT, msg)
@@ -2128,7 +2128,7 @@ func (s *Server) jsConsumerLeaderStepDownRequest(sub *subscription, c *client, _
 	if c == nil || !s.JetStreamEnabled() {
 		return
 	}
-	s.trackAPICall(JSAPIConsumerLeaderStepdown)
+	defer s.trackAPI(JSAPIConsumerLeaderStepdown)()
 	ci, acc, hdr, msg, err := s.getRequestInfo(c, rmsg)
 	if err != nil {
 		s.Warnf(badAPIRequestT, msg)
@@ -2252,7 +2252,7 @@ func (s *Server) jsStreamRemovePeerRequest(sub *subscription, c *client, _ *Acco
 	if c == nil || !s.JetStreamEnabled() {
 		return
 	}
-	s.trackAPICall(JSAPIStreamRemovePeer)
+	defer s.trackAPI(JSAPIStreamRemovePeer)()
 	ci, acc, hdr, msg, err := s.getRequestInfo(c, rmsg)
 	if err != nil {
 		s.Warnf(badAPIRequestT, msg)
@@ -2360,7 +2360,7 @@ func (s *Server) jsLeaderServerRemoveRequest(sub *subscription, c *client, _ *Ac
 	if c == nil || !s.JetStreamEnabled() {
 		return
 	}
-	s.trackAPICall(JSAPIServerRemove)
+	defer s.trackAPI(JSAPIServerRemove)()
 
 	ci, acc, hdr, msg, err := s.getRequestInfo(c, rmsg)
 	if err != nil {
@@ -2492,7 +2492,7 @@ func (s *Server) jsLeaderServerStreamMoveRequest(sub *subscription, c *client, _
 	if c == nil || !s.JetStreamEnabled() {
 		return
 	}
-	s.trackAPICall(JSAPIAccountStreamMove)
+	defer s.trackAPI(JSAPIAccountStreamMove)()
 
 	ci, acc, hdr, msg, err := s.getRequestInfo(c, rmsg)
 	if err != nil {
@@ -2657,7 +2657,7 @@ func (s *Server) jsLeaderServerStreamCancelMoveRequest(sub *subscription, c *cli
 	if c == nil || !s.JetStreamEnabled() {
 		return
 	}
-	s.trackAPICall(JSAPIAccountStreamCancelMove)
+	defer s.trackAPI(JSAPIAccountStreamCancelMove)()
 
 	ci, acc, hdr, msg, err := s.getRequestInfo(c, rmsg)
 	if err != nil {
@@ -2773,7 +2773,7 @@ func (s *Server) jsLeaderAccountPurgeRequest(sub *subscription, c *client, _ *Ac
 	if c == nil || !s.JetStreamEnabled() {
 		return
 	}
-	s.trackAPICall(JSAPIAccountPurge)
+	defer s.trackAPI(JSAPIAccountPurge)()
 
 	ci, acc, hdr, msg, err := s.getRequestInfo(c, rmsg)
 	if err != nil {
@@ -2872,7 +2872,7 @@ func (s *Server) jsLeaderStepDownRequest(sub *subscription, c *client, _ *Accoun
 	if c == nil || !s.JetStreamEnabled() {
 		return
 	}
-	s.trackAPICall(JSAPIMetaLeaderStepdown)
+	defer s.trackAPI(JSAPIMetaLeaderStepdown)()
 
 	ci, acc, hdr, msg, err := s.getRequestInfo(c, rmsg)
 	if err != nil {
@@ -3053,7 +3053,7 @@ func (s *Server) jsStreamDeleteRequest(sub *subscription, c *client, _ *Account,
 	if c == nil || !s.JetStreamEnabled() {
 		return
 	}
-	s.trackAPICall(JSAPIStreamDelete)
+	defer s.trackAPI(JSAPIStreamDelete)()
 	ci, acc, hdr, msg, err := s.getRequestInfo(c, rmsg)
 	if err != nil {
 		s.Warnf(badAPIRequestT, msg)
@@ -3127,7 +3127,7 @@ func (s *Server) jsMsgDeleteRequest(sub *subscription, c *client, _ *Account, su
 	if c == nil || !s.JetStreamEnabled() {
 		return
 	}
-	s.trackAPICall(JSAPIStreamMsgDelete)
+	defer s.trackAPI(JSAPIStreamMsgDelete)()
 	ci, acc, hdr, msg, err := s.getRequestInfo(c, rmsg)
 	if err != nil {
 		s.Warnf(badAPIRequestT, msg)
@@ -3252,7 +3252,7 @@ func (s *Server) jsMsgGetRequest(sub *subscription, c *client, _ *Account, subje
 	if c == nil || !s.JetStreamEnabled() {
 		return
 	}
-	s.trackAPICall(JSAPIStreamMsgGet)
+	defer s.trackAPI(JSAPIStreamMsgGet)()
 	ci, acc, hdr, msg, err := s.getRequestInfo(c, rmsg)
 	if err != nil {
 		s.Warnf(badAPIRequestT, msg)
@@ -3409,7 +3409,7 @@ func (s *Server) jsConsumerUnpinRequest(sub *subscription, c *client, _ *Account
 	if c == nil || !s.JetStreamEnabled() {
 		return
 	}
-	s.trackAPICall(JSAPIConsumerUnpin)
+	defer s.trackAPI(JSAPIConsumerUnpin)()
 
 	ci, acc, hdr, msg, err := s.getRequestInfo(c, rmsg)
 	if err != nil {
@@ -3550,7 +3550,7 @@ func (s *Server) jsStreamPurgeRequest(sub *subscription, c *client, _ *Account, 
 	if c == nil || !s.JetStreamEnabled() {
 		return
 	}
-	s.trackAPICall(JSAPIStreamPurge)
+	defer s.trackAPI(JSAPIStreamPurge)()
 	ci, acc, hdr, msg, err := s.getRequestInfo(c, rmsg)
 	if err != nil {
 		s.Warnf(badAPIRequestT, msg)
@@ -3700,7 +3700,7 @@ func (s *Server) jsStreamRestoreRequest(sub *subscription, c *client, _ *Account
 	if c == nil || !s.JetStreamIsLeader() {
 		return
 	}
-	s.trackAPICall(JSAPIStreamRestore)
+	defer s.trackAPI(JSAPIStreamRestore)()
 	ci, acc, hdr, msg, err := s.getRequestInfo(c, rmsg)
 	if err != nil {
 		s.Warnf(badAPIRequestT, msg)
@@ -3986,7 +3986,7 @@ func (s *Server) jsStreamSnapshotRequest(sub *subscription, c *client, _ *Accoun
 	if c == nil || !s.JetStreamEnabled() {
 		return
 	}
-	s.trackAPICall(JSAPIStreamSnapshot)
+	defer s.trackAPI(JSAPIStreamSnapshot)()
 	ci, acc, hdr, msg, err := s.getRequestInfo(c, rmsg)
 	if err != nil {
 		s.Warnf(badAPIRequestT, msg)
@@ -4227,7 +4227,7 @@ func (s *Server) jsConsumerCreateRequest(sub *subscription, c *client, a *Accoun
 	if c == nil || !s.JetStreamEnabled() {
 		return
 	}
-	s.trackAPICall(JSAPIConsumerCreate)
+	defer s.trackAPI(JSAPIConsumerCreate)()
 
 	ci, acc, hdr, msg, err := s.getRequestInfo(c, rmsg)
 	if err != nil {
@@ -4451,7 +4451,7 @@ func (s *Server) jsConsumerNamesRequest(sub *subscription, c *client, _ *Account
 	if c == nil || !s.JetStreamEnabled() {
 		return
 	}
-	s.trackAPICall(JSAPIConsumerNames)
+	defer s.trackAPI(JSAPIConsumerNames)()
 	ci, acc, hdr, msg, err := s.getRequestInfo(c, rmsg)
 	if err != nil {
 		s.Warnf(badAPIRequestT, msg)
@@ -4578,7 +4578,7 @@ func (s *Server) jsConsumerListRequest(sub *subscription, c *client, _ *Account,
 	if c == nil || !s.JetStreamEnabled() {
 		return
 	}
-	s.trackAPICall(JSAPIConsumerList)
+	defer s.trackAPI(JSAPIConsumerList)()
 
 	ci, acc, hdr, msg, err := s.getRequestInfo(c, rmsg)
 	if err != nil {
@@ -4694,7 +4694,7 @@ func (s *Server) jsConsumerInfoRequest(sub *subscription, c *client, _ *Account,
 	if c == nil || !s.JetStreamEnabled() {
 		return
 	}
-	s.trackAPICall(JSAPIConsumerInfo)
+	defer s.trackAPI(JSAPIConsumerInfo)()
 	ci, acc, hdr, msg, err := s.getRequestInfo(c, rmsg)
 	if err != nil {
 		s.Warnf(badAPIRequestT, msg)
@@ -4900,7 +4900,7 @@ func (s *Server) jsConsumerDeleteRequest(sub *subscription, c *client, _ *Accoun
 	if c == nil || !s.JetStreamEnabled() {
 		return
 	}
-	s.trackAPICall(JSAPIConsumerDelete)
+	defer s.trackAPI(JSAPIConsumerDelete)()
 	ci, acc, hdr, msg, err := s.getRequestInfo(c, rmsg)
 	if err != nil {
 		s.Warnf(badAPIRequestT, msg)
@@ -4978,7 +4978,7 @@ func (s *Server) jsConsumerPauseRequest(sub *subscription, c *client, _ *Account
 	if c == nil || !s.JetStreamEnabled() {
 		return
 	}
-	s.trackAPICall(JSAPIConsumerPause)
+	defer s.trackAPI(JSAPIConsumerPause)()
 	ci, acc, hdr, msg, err := s.getRequestInfo(c, rmsg)
 	if err != nil {
 		s.Warnf(badAPIRequestT, msg)

--- a/server/jetstream_api.go
+++ b/server/jetstream_api.go
@@ -318,99 +318,6 @@ const (
 var denyAllClientJs = []string{jsAllAPI, "$KV.>", "$OBJ.>"}
 var denyAllJs = []string{jscAllSubj, raftAllSubj, jsAllAPI, "$KV.>", "$OBJ.>"}
 
-// jsAPITypeForSubject returns the JSAPIType for a given subject.
-// This is used for traffic tracking on JetStream API calls.
-func jsAPITypeForSubject(subject string) JSAPIType {
-	// Handle $JS.ACK.* subjects
-	if strings.HasPrefix(subject, jsAckPre) {
-		return JSAPIAck
-	}
-	// Handle $JS.FC.* subjects (flow control)
-	if strings.HasPrefix(subject, jsFlowControlPre) {
-		return JSAPIFlowControl
-	}
-	// Handle $JS.API.* subjects
-	if !strings.HasPrefix(subject, JSApiPrefix) {
-		return JSAPIUnknown
-	}
-
-	// Remove the $JS.API. prefix to simplify matching
-	suffix := subject[len(JSApiPrefix)+1:] // +1 for the dot
-
-	switch {
-	case suffix == "INFO":
-		return JSAPIInfo
-
-	// Stream operations
-	case strings.HasPrefix(suffix, "STREAM.CREATE."):
-		return JSAPIStreamCreate
-	case strings.HasPrefix(suffix, "STREAM.UPDATE."):
-		return JSAPIStreamUpdate
-	case suffix == "STREAM.NAMES":
-		return JSAPIStreamNames
-	case suffix == "STREAM.LIST":
-		return JSAPIStreamList
-	case strings.HasPrefix(suffix, "STREAM.INFO."):
-		return JSAPIStreamInfo
-	case strings.HasPrefix(suffix, "STREAM.DELETE."):
-		return JSAPIStreamDelete
-	case strings.HasPrefix(suffix, "STREAM.PURGE."):
-		return JSAPIStreamPurge
-	case strings.HasPrefix(suffix, "STREAM.SNAPSHOT."):
-		return JSAPIStreamSnapshot
-	case strings.HasPrefix(suffix, "STREAM.RESTORE."):
-		return JSAPIStreamRestore
-	case strings.HasPrefix(suffix, "STREAM.PEER.REMOVE."):
-		return JSAPIStreamRemovePeer
-	case strings.HasPrefix(suffix, "STREAM.LEADER.STEPDOWN."):
-		return JSAPIStreamLeaderStepdown
-	case strings.HasPrefix(suffix, "STREAM.MSG.DELETE."):
-		return JSAPIStreamMsgDelete
-	case strings.HasPrefix(suffix, "STREAM.MSG.GET."):
-		return JSAPIStreamMsgGet
-
-	// Consumer operations
-	case strings.HasPrefix(suffix, "CONSUMER.CREATE."):
-		return JSAPIConsumerCreate
-	case strings.HasPrefix(suffix, "CONSUMER.DURABLE.CREATE."):
-		return JSAPIConsumerCreate
-	case strings.HasPrefix(suffix, "CONSUMER.NAMES."):
-		return JSAPIConsumerNames
-	case strings.HasPrefix(suffix, "CONSUMER.LIST."):
-		return JSAPIConsumerList
-	case strings.HasPrefix(suffix, "CONSUMER.INFO."):
-		return JSAPIConsumerInfo
-	case strings.HasPrefix(suffix, "CONSUMER.DELETE."):
-		return JSAPIConsumerDelete
-	case strings.HasPrefix(suffix, "CONSUMER.PAUSE."):
-		return JSAPIConsumerPause
-	case strings.HasPrefix(suffix, "CONSUMER.MSG.NEXT."):
-		return JSAPIConsumerMsgNext
-	case strings.HasPrefix(suffix, "CONSUMER.LEADER.STEPDOWN."):
-		return JSAPIConsumerLeaderStepdown
-	case strings.HasPrefix(suffix, "CONSUMER.UNPIN."):
-		return JSAPIConsumerUnpin
-
-	// Direct operations
-	case strings.HasPrefix(suffix, "DIRECT.GET."):
-		return JSAPIDirectGet
-
-	// Meta operations
-	case suffix == "META.LEADER.STEPDOWN":
-		return JSAPIMetaLeaderStepdown
-	case suffix == "SERVER.REMOVE":
-		return JSAPIServerRemove
-	case strings.HasPrefix(suffix, "ACCOUNT.PURGE."):
-		return JSAPIAccountPurge
-	case strings.HasPrefix(suffix, "ACCOUNT.STREAM.MOVE."):
-		return JSAPIAccountStreamMove
-	case strings.HasPrefix(suffix, "ACCOUNT.STREAM.CANCEL_MOVE."):
-		return JSAPIAccountStreamCancelMove
-	}
-
-	return JSAPIUnknown
-}
-
 func generateJSMappingTable(domain string) map[string]string {
 	mappings := map[string]string{}
 	// This set of mappings is very very very ugly.
@@ -926,9 +833,6 @@ func (js *jetStream) apiDispatch(sub *subscription, c *client, acc *Account, sub
 	// Increment inflight. Do this before queueing.
 	atomic.AddInt64(&js.apiInflight, 1)
 
-	// Track the API call by type for traffic stats.
-	js.trackAPICall(jsAPITypeForSubject(subject))
-
 	// Copy the state. Note the JSAPI only uses the hdr index to piece apart the
 	// header from the msg body. No other references are needed.
 	// Check pending and warn if getting backed up.
@@ -1312,6 +1216,7 @@ func (s *Server) jsAccountInfoRequest(sub *subscription, c *client, _ *Account, 
 	if c == nil || !s.JetStreamEnabled() {
 		return
 	}
+	s.trackAPICall(JSAPIInfo)
 
 	ci, acc, hdr, msg, err := s.getRequestInfo(c, rmsg)
 	if err != nil {
@@ -1408,6 +1313,7 @@ func (s *Server) jsStreamCreateRequest(sub *subscription, c *client, _ *Account,
 	if c == nil || !s.JetStreamEnabled() {
 		return
 	}
+	s.trackAPICall(JSAPIStreamCreate)
 	ci, acc, hdr, msg, err := s.getRequestInfo(c, rmsg)
 	if err != nil {
 		s.Warnf(badAPIRequestT, msg)
@@ -1524,6 +1430,7 @@ func (s *Server) jsStreamUpdateRequest(sub *subscription, c *client, _ *Account,
 	if c == nil || !s.JetStreamEnabled() {
 		return
 	}
+	s.trackAPICall(JSAPIStreamUpdate)
 
 	ci, acc, hdr, msg, err := s.getRequestInfo(c, rmsg)
 	if err != nil {
@@ -1628,6 +1535,7 @@ func (s *Server) jsStreamNamesRequest(sub *subscription, c *client, _ *Account, 
 	if c == nil || !s.JetStreamEnabled() {
 		return
 	}
+	s.trackAPICall(JSAPIStreamNames)
 	ci, acc, hdr, msg, err := s.getRequestInfo(c, rmsg)
 	if err != nil {
 		s.Warnf(badAPIRequestT, msg)
@@ -1760,6 +1668,7 @@ func (s *Server) jsStreamListRequest(sub *subscription, c *client, _ *Account, s
 	if c == nil || !s.JetStreamEnabled() {
 		return
 	}
+	s.trackAPICall(JSAPIStreamList)
 	ci, acc, hdr, msg, err := s.getRequestInfo(c, rmsg)
 	if err != nil {
 		s.Warnf(badAPIRequestT, msg)
@@ -1878,6 +1787,7 @@ func (s *Server) jsStreamInfoRequest(sub *subscription, c *client, a *Account, s
 	if c == nil || !s.JetStreamEnabled() {
 		return
 	}
+	s.trackAPICall(JSAPIStreamInfo)
 	ci, acc, hdr, msg, err := s.getRequestInfo(c, rmsg)
 	if err != nil {
 		s.Warnf(badAPIRequestT, msg)
@@ -2102,6 +2012,7 @@ func (s *Server) jsStreamLeaderStepDownRequest(sub *subscription, c *client, _ *
 	if c == nil || !s.JetStreamEnabled() {
 		return
 	}
+	s.trackAPICall(JSAPIStreamLeaderStepdown)
 	ci, acc, hdr, msg, err := s.getRequestInfo(c, rmsg)
 	if err != nil {
 		s.Warnf(badAPIRequestT, msg)
@@ -2217,6 +2128,7 @@ func (s *Server) jsConsumerLeaderStepDownRequest(sub *subscription, c *client, _
 	if c == nil || !s.JetStreamEnabled() {
 		return
 	}
+	s.trackAPICall(JSAPIConsumerLeaderStepdown)
 	ci, acc, hdr, msg, err := s.getRequestInfo(c, rmsg)
 	if err != nil {
 		s.Warnf(badAPIRequestT, msg)
@@ -2340,6 +2252,7 @@ func (s *Server) jsStreamRemovePeerRequest(sub *subscription, c *client, _ *Acco
 	if c == nil || !s.JetStreamEnabled() {
 		return
 	}
+	s.trackAPICall(JSAPIStreamRemovePeer)
 	ci, acc, hdr, msg, err := s.getRequestInfo(c, rmsg)
 	if err != nil {
 		s.Warnf(badAPIRequestT, msg)
@@ -2447,6 +2360,7 @@ func (s *Server) jsLeaderServerRemoveRequest(sub *subscription, c *client, _ *Ac
 	if c == nil || !s.JetStreamEnabled() {
 		return
 	}
+	s.trackAPICall(JSAPIServerRemove)
 
 	ci, acc, hdr, msg, err := s.getRequestInfo(c, rmsg)
 	if err != nil {
@@ -2578,6 +2492,7 @@ func (s *Server) jsLeaderServerStreamMoveRequest(sub *subscription, c *client, _
 	if c == nil || !s.JetStreamEnabled() {
 		return
 	}
+	s.trackAPICall(JSAPIAccountStreamMove)
 
 	ci, acc, hdr, msg, err := s.getRequestInfo(c, rmsg)
 	if err != nil {
@@ -2742,6 +2657,7 @@ func (s *Server) jsLeaderServerStreamCancelMoveRequest(sub *subscription, c *cli
 	if c == nil || !s.JetStreamEnabled() {
 		return
 	}
+	s.trackAPICall(JSAPIAccountStreamCancelMove)
 
 	ci, acc, hdr, msg, err := s.getRequestInfo(c, rmsg)
 	if err != nil {
@@ -2857,6 +2773,7 @@ func (s *Server) jsLeaderAccountPurgeRequest(sub *subscription, c *client, _ *Ac
 	if c == nil || !s.JetStreamEnabled() {
 		return
 	}
+	s.trackAPICall(JSAPIAccountPurge)
 
 	ci, acc, hdr, msg, err := s.getRequestInfo(c, rmsg)
 	if err != nil {
@@ -2955,6 +2872,7 @@ func (s *Server) jsLeaderStepDownRequest(sub *subscription, c *client, _ *Accoun
 	if c == nil || !s.JetStreamEnabled() {
 		return
 	}
+	s.trackAPICall(JSAPIMetaLeaderStepdown)
 
 	ci, acc, hdr, msg, err := s.getRequestInfo(c, rmsg)
 	if err != nil {
@@ -3135,6 +3053,7 @@ func (s *Server) jsStreamDeleteRequest(sub *subscription, c *client, _ *Account,
 	if c == nil || !s.JetStreamEnabled() {
 		return
 	}
+	s.trackAPICall(JSAPIStreamDelete)
 	ci, acc, hdr, msg, err := s.getRequestInfo(c, rmsg)
 	if err != nil {
 		s.Warnf(badAPIRequestT, msg)
@@ -3208,6 +3127,7 @@ func (s *Server) jsMsgDeleteRequest(sub *subscription, c *client, _ *Account, su
 	if c == nil || !s.JetStreamEnabled() {
 		return
 	}
+	s.trackAPICall(JSAPIStreamMsgDelete)
 	ci, acc, hdr, msg, err := s.getRequestInfo(c, rmsg)
 	if err != nil {
 		s.Warnf(badAPIRequestT, msg)
@@ -3332,6 +3252,7 @@ func (s *Server) jsMsgGetRequest(sub *subscription, c *client, _ *Account, subje
 	if c == nil || !s.JetStreamEnabled() {
 		return
 	}
+	s.trackAPICall(JSAPIStreamMsgGet)
 	ci, acc, hdr, msg, err := s.getRequestInfo(c, rmsg)
 	if err != nil {
 		s.Warnf(badAPIRequestT, msg)
@@ -3488,6 +3409,7 @@ func (s *Server) jsConsumerUnpinRequest(sub *subscription, c *client, _ *Account
 	if c == nil || !s.JetStreamEnabled() {
 		return
 	}
+	s.trackAPICall(JSAPIConsumerUnpin)
 
 	ci, acc, hdr, msg, err := s.getRequestInfo(c, rmsg)
 	if err != nil {
@@ -3628,6 +3550,7 @@ func (s *Server) jsStreamPurgeRequest(sub *subscription, c *client, _ *Account, 
 	if c == nil || !s.JetStreamEnabled() {
 		return
 	}
+	s.trackAPICall(JSAPIStreamPurge)
 	ci, acc, hdr, msg, err := s.getRequestInfo(c, rmsg)
 	if err != nil {
 		s.Warnf(badAPIRequestT, msg)
@@ -3777,6 +3700,7 @@ func (s *Server) jsStreamRestoreRequest(sub *subscription, c *client, _ *Account
 	if c == nil || !s.JetStreamIsLeader() {
 		return
 	}
+	s.trackAPICall(JSAPIStreamRestore)
 	ci, acc, hdr, msg, err := s.getRequestInfo(c, rmsg)
 	if err != nil {
 		s.Warnf(badAPIRequestT, msg)
@@ -4062,6 +3986,7 @@ func (s *Server) jsStreamSnapshotRequest(sub *subscription, c *client, _ *Accoun
 	if c == nil || !s.JetStreamEnabled() {
 		return
 	}
+	s.trackAPICall(JSAPIStreamSnapshot)
 	ci, acc, hdr, msg, err := s.getRequestInfo(c, rmsg)
 	if err != nil {
 		s.Warnf(badAPIRequestT, msg)
@@ -4302,6 +4227,7 @@ func (s *Server) jsConsumerCreateRequest(sub *subscription, c *client, a *Accoun
 	if c == nil || !s.JetStreamEnabled() {
 		return
 	}
+	s.trackAPICall(JSAPIConsumerCreate)
 
 	ci, acc, hdr, msg, err := s.getRequestInfo(c, rmsg)
 	if err != nil {
@@ -4525,6 +4451,7 @@ func (s *Server) jsConsumerNamesRequest(sub *subscription, c *client, _ *Account
 	if c == nil || !s.JetStreamEnabled() {
 		return
 	}
+	s.trackAPICall(JSAPIConsumerNames)
 	ci, acc, hdr, msg, err := s.getRequestInfo(c, rmsg)
 	if err != nil {
 		s.Warnf(badAPIRequestT, msg)
@@ -4651,6 +4578,7 @@ func (s *Server) jsConsumerListRequest(sub *subscription, c *client, _ *Account,
 	if c == nil || !s.JetStreamEnabled() {
 		return
 	}
+	s.trackAPICall(JSAPIConsumerList)
 
 	ci, acc, hdr, msg, err := s.getRequestInfo(c, rmsg)
 	if err != nil {
@@ -4766,6 +4694,7 @@ func (s *Server) jsConsumerInfoRequest(sub *subscription, c *client, _ *Account,
 	if c == nil || !s.JetStreamEnabled() {
 		return
 	}
+	s.trackAPICall(JSAPIConsumerInfo)
 	ci, acc, hdr, msg, err := s.getRequestInfo(c, rmsg)
 	if err != nil {
 		s.Warnf(badAPIRequestT, msg)
@@ -4971,6 +4900,7 @@ func (s *Server) jsConsumerDeleteRequest(sub *subscription, c *client, _ *Accoun
 	if c == nil || !s.JetStreamEnabled() {
 		return
 	}
+	s.trackAPICall(JSAPIConsumerDelete)
 	ci, acc, hdr, msg, err := s.getRequestInfo(c, rmsg)
 	if err != nil {
 		s.Warnf(badAPIRequestT, msg)
@@ -5048,6 +4978,7 @@ func (s *Server) jsConsumerPauseRequest(sub *subscription, c *client, _ *Account
 	if c == nil || !s.JetStreamEnabled() {
 		return
 	}
+	s.trackAPICall(JSAPIConsumerPause)
 	ci, acc, hdr, msg, err := s.getRequestInfo(c, rmsg)
 	if err != nil {
 		s.Warnf(badAPIRequestT, msg)

--- a/server/monitor.go
+++ b/server/monitor.go
@@ -2993,20 +2993,21 @@ type MetaClusterInfo struct {
 // JSInfo has detailed information on JetStream.
 type JSInfo struct {
 	JetStreamStats
-	ID              string           `json:"server_id"`
-	Now             time.Time        `json:"now"`
-	Disabled        bool             `json:"disabled,omitempty"`
-	Config          JetStreamConfig  `json:"config,omitempty"`
-	Limits          *JSLimitOpts     `json:"limits,omitempty"`
-	Streams         int              `json:"streams"`
-	StreamsLeader   int              `json:"streams_leader,omitempty"`
-	Consumers       int              `json:"consumers"`
-	ConsumersLeader int              `json:"consumers_leader,omitempty"`
-	Messages        uint64           `json:"messages"`
-	Bytes           uint64           `json:"bytes"`
-	Meta            *MetaClusterInfo `json:"meta_cluster,omitempty"`
-	AccountDetails  []*AccountDetail `json:"account_details,omitempty"`
-	Total           int              `json:"total"`
+	ID              string              `json:"server_id"`
+	Now             time.Time           `json:"now"`
+	Disabled        bool                `json:"disabled,omitempty"`
+	Config          JetStreamConfig     `json:"config,omitempty"`
+	Limits          *JSLimitOpts        `json:"limits,omitempty"`
+	Streams         int                 `json:"streams"`
+	StreamsLeader   int                 `json:"streams_leader,omitempty"`
+	Consumers       int                 `json:"consumers"`
+	ConsumersLeader int                 `json:"consumers_leader,omitempty"`
+	Messages        uint64              `json:"messages"`
+	Bytes           uint64              `json:"bytes"`
+	Meta            *MetaClusterInfo    `json:"meta_cluster,omitempty"`
+	ApiStats        *JSAPITrafficStats  `json:"api_stats,omitempty"`
+	AccountDetails  []*AccountDetail    `json:"account_details,omitempty"`
+	Total           int                 `json:"total"`
 }
 
 func (s *Server) accountDetail(jsa *jsAccount, optStreams, optConsumers, optDirectConsumers, optCfg, optRaft, optStreamLeader bool) *AccountDetail {
@@ -3234,6 +3235,7 @@ func (s *Server) Jsz(opts *JSzOptions) (*JSInfo, error) {
 	}
 
 	jsi.JetStreamStats = *js.usageStats()
+	jsi.ApiStats = js.apiTrafficStats()
 
 	// If a specific account is requested, track the index.
 	filterIdx := -1

--- a/server/monitor.go
+++ b/server/monitor.go
@@ -3235,7 +3235,7 @@ func (s *Server) Jsz(opts *JSzOptions) (*JSInfo, error) {
 	}
 
 	jsi.JetStreamStats = *js.usageStats()
-	jsi.ApiStats = js.apiTrafficStats()
+	jsi.ApiStats = js.apiStats()
 
 	// If a specific account is requested, track the index.
 	filterIdx := -1

--- a/server/monitor_test.go
+++ b/server/monitor_test.go
@@ -5566,6 +5566,79 @@ func TestMonitorJszApiStats(t *testing.T) {
 	}
 }
 
+func TestMonitorJszApiLatencyStats(t *testing.T) {
+	s := RunBasicJetStreamServer(t)
+	defer s.Shutdown()
+
+	nc, js := jsClientConnect(t, s)
+	defer nc.Close()
+
+	// Perform multiple API calls to generate latency data
+	for i := 0; i < 10; i++ {
+		streamName := fmt.Sprintf("TEST_%d", i)
+		_, err := js.AddStream(&nats.StreamConfig{
+			Name:     streamName,
+			Subjects: []string{fmt.Sprintf("test.%d.>", i)},
+		})
+		require_NoError(t, err)
+
+		// Create a consumer
+		_, err = js.AddConsumer(streamName, &nats.ConsumerConfig{
+			Durable:   fmt.Sprintf("TEST-CONSUMER-%d", i),
+			AckPolicy: nats.AckExplicitPolicy,
+		})
+		require_NoError(t, err)
+
+		// Get stream info
+		_, err = js.StreamInfo(streamName)
+		require_NoError(t, err)
+	}
+
+	// Get API stats with latency data
+	jsi, err := s.Jsz(nil)
+	require_NoError(t, err)
+	require_NotNil(t, jsi.ApiStats)
+
+	// Verify latency data exists and is valid
+	require_NotNil(t, jsi.ApiStats.Latency)
+
+	// Verify StreamCreate latency is present and has valid values
+	require_NotNil(t, jsi.ApiStats.Latency.StreamCreate)
+	streamCreateLatency := jsi.ApiStats.Latency.StreamCreate
+	if streamCreateLatency.Min <= 0 {
+		t.Fatalf("expected stream_create min latency > 0, got %d", streamCreateLatency.Min)
+	}
+	if streamCreateLatency.Max < streamCreateLatency.Min {
+		t.Fatalf("expected stream_create max latency >= min, got max=%d, min=%d", streamCreateLatency.Max, streamCreateLatency.Min)
+	}
+	if streamCreateLatency.P50 < streamCreateLatency.Min || streamCreateLatency.P50 > streamCreateLatency.Max {
+		t.Fatalf("expected stream_create p50 to be between min and max, got p50=%d, min=%d, max=%d", streamCreateLatency.P50, streamCreateLatency.Min, streamCreateLatency.Max)
+	}
+	if streamCreateLatency.P90 < streamCreateLatency.P50 || streamCreateLatency.P90 > streamCreateLatency.Max {
+		t.Fatalf("expected stream_create p90 to be between p50 and max, got p90=%d, p50=%d, max=%d", streamCreateLatency.P90, streamCreateLatency.P50, streamCreateLatency.Max)
+	}
+	if streamCreateLatency.P99 < streamCreateLatency.P90 || streamCreateLatency.P99 > streamCreateLatency.Max {
+		t.Fatalf("expected stream_create p99 to be between p90 and max, got p99=%d, p90=%d, max=%d", streamCreateLatency.P99, streamCreateLatency.P90, streamCreateLatency.Max)
+	}
+	if streamCreateLatency.Avg < float64(streamCreateLatency.Min) || streamCreateLatency.Avg > float64(streamCreateLatency.Max) {
+		t.Fatalf("expected stream_create avg latency to be between min and max, got avg=%f, min=%d, max=%d", streamCreateLatency.Avg, streamCreateLatency.Min, streamCreateLatency.Max)
+	}
+
+	// Verify ConsumerCreate latency is present
+	require_NotNil(t, jsi.ApiStats.Latency.ConsumerCreate)
+	consumerCreateLatency := jsi.ApiStats.Latency.ConsumerCreate
+	if consumerCreateLatency.Min <= 0 {
+		t.Fatalf("expected consumer_create min latency > 0, got %d", consumerCreateLatency.Min)
+	}
+
+	// Verify StreamInfo latency is present
+	require_NotNil(t, jsi.ApiStats.Latency.StreamInfo)
+	streamInfoLatency := jsi.ApiStats.Latency.StreamInfo
+	if streamInfoLatency.Min <= 0 {
+		t.Fatalf("expected stream_info min latency > 0, got %d", streamInfoLatency.Min)
+	}
+}
+
 func TestMonitorReloadTLSConfig(t *testing.T) {
 	template := `
 		listen: "127.0.0.1:-1"

--- a/server/monitor_test.go
+++ b/server/monitor_test.go
@@ -5608,14 +5608,11 @@ func TestMonitorJszApiLatencyStats(t *testing.T) {
 	if streamCreateLatency.P50 <= 0 {
 		t.Fatalf("expected stream_create p50 latency > 0, got %d", streamCreateLatency.P50)
 	}
-	if streamCreateLatency.Max < streamCreateLatency.P50 {
-		t.Fatalf("expected stream_create max latency >= p50, got max=%d, p50=%d", streamCreateLatency.Max, streamCreateLatency.P50)
+	if streamCreateLatency.P90 < streamCreateLatency.P50 {
+		t.Fatalf("expected stream_create p90 >= p50, got p90=%d, p50=%d", streamCreateLatency.P90, streamCreateLatency.P50)
 	}
-	if streamCreateLatency.P90 < streamCreateLatency.P50 || streamCreateLatency.P90 > streamCreateLatency.Max {
-		t.Fatalf("expected stream_create p90 to be between p50 and max, got p90=%d, p50=%d, max=%d", streamCreateLatency.P90, streamCreateLatency.P50, streamCreateLatency.Max)
-	}
-	if streamCreateLatency.P99 < streamCreateLatency.P90 || streamCreateLatency.P99 > streamCreateLatency.Max {
-		t.Fatalf("expected stream_create p99 to be between p90 and max, got p99=%d, p90=%d, max=%d", streamCreateLatency.P99, streamCreateLatency.P90, streamCreateLatency.Max)
+	if streamCreateLatency.P99 < streamCreateLatency.P90 {
+		t.Fatalf("expected stream_create p99 >= p90, got p99=%d, p90=%d", streamCreateLatency.P99, streamCreateLatency.P90)
 	}
 
 	// Verify ConsumerCreate latency is present

--- a/server/monitor_test.go
+++ b/server/monitor_test.go
@@ -5605,14 +5605,11 @@ func TestMonitorJszApiLatencyStats(t *testing.T) {
 	// Verify StreamCreate latency is present and has valid values
 	require_NotNil(t, jsi.ApiStats.Latency.StreamCreate)
 	streamCreateLatency := jsi.ApiStats.Latency.StreamCreate
-	if streamCreateLatency.Min <= 0 {
-		t.Fatalf("expected stream_create min latency > 0, got %d", streamCreateLatency.Min)
+	if streamCreateLatency.P50 <= 0 {
+		t.Fatalf("expected stream_create p50 latency > 0, got %d", streamCreateLatency.P50)
 	}
-	if streamCreateLatency.Max < streamCreateLatency.Min {
-		t.Fatalf("expected stream_create max latency >= min, got max=%d, min=%d", streamCreateLatency.Max, streamCreateLatency.Min)
-	}
-	if streamCreateLatency.P50 < streamCreateLatency.Min || streamCreateLatency.P50 > streamCreateLatency.Max {
-		t.Fatalf("expected stream_create p50 to be between min and max, got p50=%d, min=%d, max=%d", streamCreateLatency.P50, streamCreateLatency.Min, streamCreateLatency.Max)
+	if streamCreateLatency.Max < streamCreateLatency.P50 {
+		t.Fatalf("expected stream_create max latency >= p50, got max=%d, p50=%d", streamCreateLatency.Max, streamCreateLatency.P50)
 	}
 	if streamCreateLatency.P90 < streamCreateLatency.P50 || streamCreateLatency.P90 > streamCreateLatency.Max {
 		t.Fatalf("expected stream_create p90 to be between p50 and max, got p90=%d, p50=%d, max=%d", streamCreateLatency.P90, streamCreateLatency.P50, streamCreateLatency.Max)
@@ -5620,22 +5617,19 @@ func TestMonitorJszApiLatencyStats(t *testing.T) {
 	if streamCreateLatency.P99 < streamCreateLatency.P90 || streamCreateLatency.P99 > streamCreateLatency.Max {
 		t.Fatalf("expected stream_create p99 to be between p90 and max, got p99=%d, p90=%d, max=%d", streamCreateLatency.P99, streamCreateLatency.P90, streamCreateLatency.Max)
 	}
-	if streamCreateLatency.Avg < float64(streamCreateLatency.Min) || streamCreateLatency.Avg > float64(streamCreateLatency.Max) {
-		t.Fatalf("expected stream_create avg latency to be between min and max, got avg=%f, min=%d, max=%d", streamCreateLatency.Avg, streamCreateLatency.Min, streamCreateLatency.Max)
-	}
 
 	// Verify ConsumerCreate latency is present
 	require_NotNil(t, jsi.ApiStats.Latency.ConsumerCreate)
 	consumerCreateLatency := jsi.ApiStats.Latency.ConsumerCreate
-	if consumerCreateLatency.Min <= 0 {
-		t.Fatalf("expected consumer_create min latency > 0, got %d", consumerCreateLatency.Min)
+	if consumerCreateLatency.P50 <= 0 {
+		t.Fatalf("expected consumer_create p50 latency > 0, got %d", consumerCreateLatency.P50)
 	}
 
 	// Verify StreamInfo latency is present
 	require_NotNil(t, jsi.ApiStats.Latency.StreamInfo)
 	streamInfoLatency := jsi.ApiStats.Latency.StreamInfo
-	if streamInfoLatency.Min <= 0 {
-		t.Fatalf("expected stream_info min latency > 0, got %d", streamInfoLatency.Min)
+	if streamInfoLatency.P50 <= 0 {
+		t.Fatalf("expected stream_info p50 latency > 0, got %d", streamInfoLatency.P50)
 	}
 }
 

--- a/server/stream.go
+++ b/server/stream.go
@@ -5003,6 +5003,10 @@ func (mset *stream) processDirectGetRequest(_ *subscription, c *client, _ *Accou
 	if len(reply) == 0 {
 		return
 	}
+	// Track the API call for traffic stats.
+	if mset.js != nil {
+		mset.js.trackAPICall(JSAPIDirectGet)
+	}
 	hdr, msg := c.msgParts(rmsg)
 	if errorOnRequiredApiLevel(hdr) {
 		hdr := []byte("NATS/1.0 412 Required Api Level\r\n\r\n")

--- a/server/stream.go
+++ b/server/stream.go
@@ -5013,9 +5013,9 @@ func (mset *stream) processDirectGetRequest(_ *subscription, c *client, _ *Accou
 	if len(reply) == 0 {
 		return
 	}
-	// Track the API call for traffic stats.
+	// Track the API call for traffic stats with latency.
 	if mset.js != nil {
-		mset.js.trackAPICall(JSAPIDirectGet)
+		defer mset.js.trackAPI(JSAPIDirectGet)()
 	}
 	hdr, msg := c.msgParts(rmsg)
 	if errorOnRequiredApiLevel(hdr) {


### PR DESCRIPTION
This commit adds atomic counters for each JetStream API subject type
($JS.API.* and $JS.ACK.*) and exposes them through the Jsz monitoring
endpoint.

Features:
- New JSAPITrafficStats struct with per-subject counters
- Track all API calls in apiDispatch by subject type
- Track ACK messages in consumer.pushAck
- Track flow control messages in consumer.processFlowControl
- Expose traffic stats via Jsz under the "api_stats" field

API subjects tracked:
- INFO, STREAM.*, CONSUMER.*, DIRECT.*, META.*, ACCOUNT.*
- ACK and FlowControl messages